### PR TITLE
Add optional Plotly HTML plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ export bitrate data to CSV or JSON and save the plot image for later analysis.
 
 ```bash
 python main.py VIDEO [--bucket SECS] [--export-csv FILE] [--export-json FILE] \
-                     [--save-plot IMAGE] [--stats]
+                     [--save-plot IMAGE] [--stats] [--plotly-html FILE]
 ```
 
 * `VIDEO` – path to the input video file.
@@ -19,6 +19,7 @@ python main.py VIDEO [--bucket SECS] [--export-csv FILE] [--export-json FILE] \
   the specified file.
 * `--save-plot` – save the plot to an image file in addition to displaying it.
 * `--stats` – overlay minimum, maximum and average bitrates on the plot.
+* `--plotly-html` – write an interactive HTML plot using Plotly.
 
 Running the script pops up a plot window showing the average bitrate (in kbps)
 for each time bucket.
@@ -28,5 +29,6 @@ for each time bucket.
 - Python 3
 - `ffprobe` available in `PATH` (ships with FFmpeg)
 - `matplotlib`
+- `plotly`
 
-Install dependencies with `pip install matplotlib` if needed.
+Install dependencies with `pip install matplotlib plotly` if needed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 matplotlib==3.10.3
+plotly==5.22.0


### PR DESCRIPTION
## Summary
- add Plotly dependency
- add `--plotly-html` option
- generate interactive HTML plot when requested
- document the new flag and dependency

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6858e17cb95083209f65047e54fb6062