### PR TITLE
Add optional I-frame markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ export bitrate data to CSV or JSON and save the plot image for later analysis.
 ```bash
 python main.py VIDEO [--bucket SECS] [--export-csv FILE] [--export-json FILE] \
                      [--save-plot IMAGE] [--stats] [--stats-file FILE] \
-                     [--plotly-html FILE] [--target-bitrate KBPS]
+                     [--plotly-html FILE] [--target-bitrate KBPS] \
+                     [--mark-iframes]
 ```
 
 * `VIDEO` – path to the input video file.
@@ -23,6 +24,8 @@ python main.py VIDEO [--bucket SECS] [--export-csv FILE] [--export-json FILE] \
 * `--stats-file` – optional path to write the bitrate summary.
 * `--plotly-html` – write an interactive HTML plot using Plotly.
 * `--target-bitrate` – draw a reference line at the given average bitrate.
+* `--mark-iframes` – overlay vertical markers at I-frame times. This flag
+  triggers an additional `ffprobe -show_frames` pass to detect frame types.
 
 Running the script pops up a plot window showing the average bitrate (in kbps)
 for each time bucket.


### PR DESCRIPTION
## Summary
- add `--mark-iframes` option
- detect I-frames with `ffprobe -show_frames`
- show vertical I-frame markers in matplotlib and plotly
- document new flag in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6858edaa47c88320a8919fba4cb3b89d